### PR TITLE
Fix readme guideline menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Formats (templates) des factures
 
 ## Principe
 En utilisant notre logiciel de facturation, vous avez accès à un certain nombre de formats de factures (mises en page). </br>
-Si l'un d'eux ne répond pas à vos attentes, <b>vous pouvez créer votre propre modèle</b>.</br> 
-Il vous suffit de vous connecter à votre compte (si vous n'êtes pas encore inscrit : https://app.vosfactures.fr/signup pour un essai gratuit), de cliquer sur Paramètres > Paramètres du compte > Formats d'impression, puis de cliquer sur le bouton "Ajouter un nouveau format". Vous pouvez choisir le format par défaut que vous souhaitez modifier, comme expliqué ici: https://aide.vosfactures.fr/8631976-Cr-er-un-format-personnalis-
+Si l'un d'eux ne répond pas à vos attentes, <b>vous pouvez créer votre propre modèle</b>.</br>
+Il vous suffit de vous connecter à votre compte (si vous n'êtes pas encore inscrit : https://app.vosfactures.fr/signup pour un essai gratuit), de cliquer sur Paramètres > Paramètres du compte > Formats des documents, puis de cliquer sur le bouton "Ajouter un nouveau format". Vous pouvez choisir le format par défaut que vous souhaitez modifier, comme expliqué ici: https://aide.vosfactures.fr/8631976-Cr-er-un-format-personnalis-
 
 ## Documentation 
 


### PR DESCRIPTION
Hello,

J'ai renommé le menu anciennement "Formats d'impression", devenu "Formats des documents" : 

<img width="219" alt="Capture_d’écran_2020-01-16_à_18_21_51" src="https://user-images.githubusercontent.com/574275/72547686-62f52a80-388d-11ea-8ee7-c725076b44ff.png">
